### PR TITLE
Removing mongodb as a dependency.

### DIFF
--- a/topological_navigation/CMakeLists.txt
+++ b/topological_navigation/CMakeLists.txt
@@ -4,7 +4,7 @@ project(topological_navigation)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS rospy std_msgs nav_msgs sensor_msgs actionlib_msgs topological_navigation_msgs mongodb_store message_generation)
+find_package(catkin REQUIRED COMPONENTS rospy std_msgs nav_msgs sensor_msgs actionlib_msgs topological_navigation_msgs message_generation)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)

--- a/topological_navigation/package.xml
+++ b/topological_navigation/package.xml
@@ -25,7 +25,7 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>actionlib</build_depend>
   <build_depend>actionlib_msgs</build_depend>
-  <build_depend>mongodb_store</build_depend>
+  <!--build_depend>mongodb_store</build_depend-->
   <build_depend>visualization_msgs</build_depend>
   <build_depend>rospy_message_converter</build_depend>
   <build_depend>topological_navigation_msgs</build_depend>
@@ -39,7 +39,7 @@
   <run_depend>sensor_msgs</run_depend>
   <run_depend>actionlib</run_depend>
   <run_depend>actionlib_msgs</run_depend>
-  <run_depend>mongodb_store</run_depend>
+  <!--run_depend>mongodb_store</run_depend-->
   <run_depend>visualization_msgs</run_depend>
   <run_depend>dwa_local_planner</run_depend>
   <run_depend>rospy_message_converter</run_depend>

--- a/topological_utils/CMakeLists.txt
+++ b/topological_utils/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(topological_utils)
 
-find_package(catkin REQUIRED rospy roscpp std_msgs geometry_msgs message_generation mongodb_store visualization_msgs)
+find_package(catkin REQUIRED rospy roscpp std_msgs geometry_msgs message_generation visualization_msgs)
 
 ## Uncomment this if the package has a setup.py. This macro ensures
 ## modules and global scripts declared therein get installed

--- a/topological_utils/package.xml
+++ b/topological_utils/package.xml
@@ -18,7 +18,7 @@
   <build_depend>rospy</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>geometry_msgs</build_depend>
-  <build_depend>mongodb_store</build_depend>
+  <!--build_depend>mongodb_store</build_depend-->
   <build_depend>visualization_msgs</build_depend>
   <build_depend>topological_navigation</build_depend>
   <build_depend>topological_rviz_tools</build_depend>
@@ -26,7 +26,7 @@
   <run_depend>rospy</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>geometry_msgs</run_depend>
-  <run_depend>mongodb_store</run_depend>
+  <!--run_depend>mongodb_store</run_depend-->
   <run_depend>visualization_msgs</run_depend>
   <run_depend>topological_navigation</run_depend>
   <run_depend>topological_rviz_tools</run_depend>


### PR DESCRIPTION
Removed from `topological_navigation` and `topological_utils` packages.