### PR TITLE
Additional edge reconfigure functionality.

### DIFF
--- a/topological_navigation/src/topological_navigation/edge_reconfigure_manager.py
+++ b/topological_navigation/src/topological_navigation/edge_reconfigure_manager.py
@@ -61,10 +61,13 @@ class EdgeReconfigureManager(object):
 
             for param in self.edge["config"]:
                 if param["namespace"] == namespace:
-                    self.initial_config[namespace][param["name"]] = config[param["name"]]
                     self.edge_config[namespace][param["name"]] = param["value"]
-                
-        
+
+                    reset = True if "reset" not in param else param["reset"]
+                    if reset:
+                        self.initial_config[namespace][param["name"]] = config[param["name"]]
+
+
     def reconfigure(self):
         """
         If using the new map then edge reconfigure is done using settings in the map.
@@ -79,8 +82,9 @@ class EdgeReconfigureManager(object):
         Used to reset edge params to their default values when the action has completed (only if using the new map)
         """
         for namespace in self.initial_config:
-            rospy.loginfo("Edge Reconfigure Manager: Resetting {} = {}".format(namespace, self.initial_config[namespace]))            
-            self.update(namespace, self.initial_config[namespace])
+            if self.initial_config[namespace]:
+                rospy.loginfo("Edge Reconfigure Manager: Resetting {} = {}".format(namespace, self.initial_config[namespace]))
+                self.update(namespace, self.initial_config[namespace])
                 
                 
     def update(self, namespace, params):

--- a/topological_navigation/src/topological_navigation/manager2.py
+++ b/topological_navigation/src/topological_navigation/manager2.py
@@ -876,10 +876,10 @@ class map_manager_2(object):
         """
         Update edge reconfigure parameters.
         """
-        return self.add_param_to_edge_config(req.edge_id, req.namespace, req.name, req.value, req.value_is_string)
+        return self.add_param_to_edge_config(req.edge_id, req.namespace, req.name, req.value, req.value_is_string, req.not_reset)
     
     
-    def add_param_to_edge_config(self, edge_id, namespace, name, value, value_is_string, update=True, write_map=True):
+    def add_param_to_edge_config(self, edge_id, namespace, name, value, value_is_string, not_reset, update=True, write_map=True):
         
         if not value:
             return False, "no value provided"
@@ -890,7 +890,7 @@ class map_manager_2(object):
         node_name, _ = get_node_names_from_edge_id_2(self.tmap2, edge_id)
         num_available, index = self.get_instances_of_node(node_name)
         
-        param = {"namespace":namespace, "name":name, "value":value}
+        param = {"namespace":namespace, "name":name, "value":value, "reset":not not_reset}
 
         if num_available == 1:
             the_node = copy.deepcopy(self.tmap2["nodes"][index])
@@ -1248,7 +1248,7 @@ class map_manager_2(object):
     def add_params_to_edges(self, data, update=True, write_map=True):
 
         for item in data:
-            success,_ = self.add_param_to_edge_config(item.edge_id, item.namespace, item.name, item.value, item.value_is_string, update=False, write_map=False)
+            success,_ = self.add_param_to_edge_config(item.edge_id, item.namespace, item.name, item.value, item.value_is_string, item.not_reset, update=False, write_map=False)
             if not success:
                 return False
 

--- a/topological_navigation_msgs/msg/UpdateEdgeConfigReq.msg
+++ b/topological_navigation_msgs/msg/UpdateEdgeConfigReq.msg
@@ -3,3 +3,4 @@ string namespace
 string name
 string value        # python uses its eval function to determine the type unless it is a string
 bool value_is_string
+bool not_reset      # if false then the param is reconfigured back to its original value after the edge is traversed

--- a/topological_navigation_msgs/srv/UpdateEdgeConfig.srv
+++ b/topological_navigation_msgs/srv/UpdateEdgeConfig.srv
@@ -3,6 +3,7 @@ string namespace
 string name
 string value        # python uses its eval function to determine the type unless it is a string
 bool value_is_string
+bool not_reset      # if false then the param is reconfigured back to its original value after the edge is traversed
 ---
 bool success
 string message


### PR DESCRIPTION
By default edge reconfigure resets the param back to its original value after the edge is traversed.
This behaviour is now optional and can be disabled in the topological map edge config by setting `reset: false` for a given param.
Updated map manager services accordingly.