### PR TITLE
Replace install -> catkin_install_python in CMakeLists

### DIFF
--- a/bayesian_topological_localisation/CMakeLists.txt
+++ b/bayesian_topological_localisation/CMakeLists.txt
@@ -129,7 +129,7 @@ include_directories(
 # all install targets should use catkin DESTINATION variables
 # See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
 
- install(PROGRAMS
+ catkin_install_python(PROGRAMS
    scripts/localisation_node.py
    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
  )

--- a/topological_navigation/CMakeLists.txt
+++ b/topological_navigation/CMakeLists.txt
@@ -120,7 +120,7 @@ include_directories(
 # all install targets should use catkin DESTINATION variables
 # See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
 
- install(PROGRAMS
+catkin_install_python(PROGRAMS
    scripts/localisation.py
    scripts/nav_client.py
    scripts/navigation.py

--- a/topological_rviz_tools/CMakeLists.txt
+++ b/topological_rviz_tools/CMakeLists.txt
@@ -97,7 +97,7 @@ foreach (dir launch images conf)
 endforeach(dir)
 
 
-install(PROGRAMS
+catkin_install_python(PROGRAMS
   scripts/python_topmap_interface.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/topological_utils/CMakeLists.txt
+++ b/topological_utils/CMakeLists.txt
@@ -26,7 +26,7 @@ add_service_files(
 )
 generate_messages(
 DEPENDENCIES
-    std_msgs 
+    std_msgs
 )
 catkin_package(
 #  INCLUDE_DIRS include
@@ -72,7 +72,7 @@ catkin_package(
 
 ## Mark executable scripts (Python etc.) for installation
 ## in contrast to setup.py, you can choose the destination
- install(PROGRAMS
+ catkin_install_python(PROGRAMS
    scripts/add_content.py
    scripts/add_edge.py
    scripts/add_node.py


### PR DESCRIPTION
This change makes sure that when catkin builds the package, any `#!/usr/bin/env python` is replaced with the default python version for the relevant ROS distribution, instead of requiring Python2. Meaning as long as the code itself is compatible with Python3, there's no need to change the shebang for it to work with Noetic.

See docs here: http://docs.ros.org/en/jade/api/catkin/html/howto/format2/installing_python.html