### PR TITLE
Service for setting the topological map version. Automatically set to…

### DIFF
--- a/topological_navigation_msgs/CMakeLists.txt
+++ b/topological_navigation_msgs/CMakeLists.txt
@@ -82,6 +82,7 @@ add_service_files(
   AddNodeArray.srv
   SetInfluenceZoneArray.srv
   UpdateEdgeConfigArray.srv
+  SetVersion.srv
 )
 
 

--- a/topological_navigation_msgs/srv/SetVersion.srv
+++ b/topological_navigation_msgs/srv/SetVersion.srv
@@ -1,0 +1,3 @@
+string version
+---
+bool success


### PR DESCRIPTION
… 0.1 when making a new map.

Example `rosservice call /topological_map_manager2/set_version "version: '0.2'" `

Service type is `topological_navigation_msgs.srv.SetVersion`