### PR TITLE
Remove goal field from topomaps by default.

### DIFF
--- a/topological_navigation/launch/topological_navigation.launch
+++ b/topological_navigation/launch/topological_navigation.launch
@@ -8,9 +8,11 @@
   <!-- Filename of the topological map. -->
   <arg name="file" default=""/>
   <!-- Cache the topological map in `.ros/topological_maps` when loading in map manager 2. -->
-  <arg name="cache_topological_maps" default="true"/>
+  <arg name="cache_topological_maps" default="false"/>
   <!-- Automatically save changes to the topological map after a service call. -->
-  <arg name="auto_write_topological_maps" default="true"/>
+  <arg name="auto_write_topological_maps" default="false"/>
+    <!-- If False then there should be a plugin for all actions in the topomap. -->
+  <arg name="set_goal_in_topological_maps" default="false"/>
   <!-- Pointset of the topological map (its name in the mongo database). --> 	
   <arg name="pointset" default=""/> 
   <!-- If false load a tmap2 using the map manager 2, else load a tmap using the legacy map manager. -->

--- a/topological_navigation/scripts/navigation.py
+++ b/topological_navigation/scripts/navigation.py
@@ -269,7 +269,7 @@ class TopologicalNavServer(object):
                 for edge in node["node"]["edges"]:
                     if edge["action"] == self.move_base_name:
                         move_base_goal["action_type"] = edge["action_type"]
-                        move_base_goal["goal"] = edge["goal"]
+                        move_base_goal["goal"] = edge["goal"] if "goal" in edge else {}
                         break
                 else:
                     continue

--- a/topological_navigation/src/topological_navigation/manager2.py
+++ b/topological_navigation/src/topological_navigation/manager2.py
@@ -44,9 +44,11 @@ class map_manager_2(object):
         
         self.cache_maps = rospy.get_param("~cache_topological_maps", False)
         self.auto_write = rospy.get_param("~auto_write_topological_maps", False)
+        self.set_goal_in_tmap = rospy.get_param("set_goal_in_topological_maps", False)
 
         rospy.loginfo("cache_topological_maps: {}".format(self.cache_maps))
         rospy.loginfo("auto_write_topological_maps: {}".format(self.auto_write))
+        rospy.loginfo("set_goal_in_topological_maps: {}".format(self.set_goal_in_tmap))
 
         self.cache_dir = os.path.join(os.path.expanduser("~"), ".ros", "topological_maps")     
         if not os.path.exists(self.cache_dir):
@@ -636,10 +638,16 @@ class map_manager_2(object):
         if not action_type:
             action_type = "move_base_msgs/MoveBaseGoal"
         
-        the_action_type, the_goal = self.set_goal(action, action_type, goal)
+        if self.set_goal_in_tmap or action_type == "move_base_msgs/MoveBaseGoal":
+            the_action_type, the_goal = self.set_goal(action, action_type, goal)
+        else:
+            the_action_type = action_type
+            the_goal = None
         
         edge["action_type"] = the_action_type
-        edge["goal"] = the_goal
+
+        if the_goal:
+            edge["goal"] = the_goal
         
         edge["fail_policy"] = fail_policy
         edge["restrictions_planning"] = restrictions_planning


### PR DESCRIPTION
Unless the action_type is `move_base_msgs/MoveBaseGoal`
We have been using plugins for a long time now and no longer need it. Will reduce the size of tmaps considerably. 