### PR TITLE
Option to remove fields from the published topological map.

### DIFF
--- a/topological_navigation/scripts/navigation.py
+++ b/topological_navigation/scripts/navigation.py
@@ -270,9 +270,7 @@ class TopologicalNavServer(object):
                 for edge in node["node"]["edges"]:
                     if edge["action"] == self.move_base_name:
                         move_base_goal["action_type"] = edge["action_type"]
-                        move_base_goal["goal"] = {}
-                        if "goal" in edge:
-                            move_base_goal["goal"] = edge["goal"]
+                        move_base_goal["goal"] = edge["goal"] if "goal" in edge else {}
                         break
                 else:
                     continue
@@ -739,9 +737,7 @@ class TopologicalNavServer(object):
             if rindex < (len(route.edge_id) - 1):
                 nedge = get_edge_from_id_tmap2(self.lnodes, route.source[rindex + 1], route.edge_id[rindex + 1])
                 a1 = nedge["action"]
-                self.fluid_navigation = True
-                if "fluid_navigation" in nedge:
-                    self.fluid_navigation = nedge["fluid_navigation"]
+                self.fluid_navigation = nedge["fluid_navigation"] if "fluid_navigation" in nedge else True
             else:
                 nedge = None
                 a1 = "none"

--- a/topological_navigation/scripts/navigation.py
+++ b/topological_navigation/scripts/navigation.py
@@ -270,7 +270,9 @@ class TopologicalNavServer(object):
                 for edge in node["node"]["edges"]:
                     if edge["action"] == self.move_base_name:
                         move_base_goal["action_type"] = edge["action_type"]
-                        move_base_goal["goal"] = edge["goal"]
+                        move_base_goal["goal"] = {}
+                        if "goal" in edge:
+                            move_base_goal["goal"] = edge["goal"]
                         break
                 else:
                     continue
@@ -737,7 +739,9 @@ class TopologicalNavServer(object):
             if rindex < (len(route.edge_id) - 1):
                 nedge = get_edge_from_id_tmap2(self.lnodes, route.source[rindex + 1], route.edge_id[rindex + 1])
                 a1 = nedge["action"]
-                self.fluid_navigation = nedge["fluid_navigation"]
+                self.fluid_navigation = True
+                if "fluid_navigation" in nedge:
+                    self.fluid_navigation = nedge["fluid_navigation"]
             else:
                 nedge = None
                 a1 = "none"


### PR DESCRIPTION
Set by parameter `/topological_map_manager2/publish_simple_topo_map` (default `True`)

For a node removes `["meta"]["map"]`, `["meta"]["pointset"]`,` ["restrictions_planning"]`, `["restrictions_runtime"]`

For an edge removes `["fail_policy"]`, `["fluid_navigation"]`, `["goal"]`, `["recovery_behaviours_config"]`,  `["restrictions_planning"]`, `["restrictions_runtime"]`

Also the legacy topological map is not published by default