### PR TITLE
correct bug in tag finding

### DIFF
--- a/topological_navigation/src/topological_navigation/manager2.py
+++ b/topological_navigation/src/topological_navigation/manager2.py
@@ -446,10 +446,11 @@ class map_manager_2(object):
         res.poses=[]
         for node in self.tmap2["nodes"]:
             if "tag" in node["meta"]:
-                if req.tag in node["meta"]["tag"]:
-                    pose = message_converter.convert_dictionary_to_ros_message("geometry_msgs/Pose", node["node"]["pose"])
-                    res.nodes.append(node["node"]["name"])
-                    res.poses.append(pose)
+                for tag in node["meta"]["tag"]:
+                    if str(tag) == str(req.tag):
+                        pose = message_converter.convert_dictionary_to_ros_message("geometry_msgs/Pose", node["node"]["pose"])
+                        res.nodes.append(node["node"]["name"])
+                        res.poses.append(pose)
         return res
 
 


### PR DESCRIPTION
found an issue in bruce farms where the names of the fields are just number. The tags to make the highway work could not be found when calling the service because of this line: https://github.com/SAGARobotics/topological_navigation/pull/74/files#diff-899e2ef025eb80fb0fcf7fd387c605a1fe39641d9ac3b2e4e3f8985a47a74ccbL449

the proposal is to force casting to string. But you decide how to best approach this Adam